### PR TITLE
faster performance using NOT IN when applicable

### DIFF
--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -142,32 +142,34 @@ class SelectionFilter:
 
         selection = layer.selectedFeatures()
 
-        if len(selection):
-            fields = {f.name(): f.type() for f in layer.fields()}
-            if field in fields:
-                unique_values = list(set(feature[field] for feature in selection))
-
-                if len(unique_values) > 1:
-                    query_syntax = f"{field} IN {tuple(unique_values)}"
-                else:
-                    query_syntax = f"{field} IN ({unique_values[0]})"
-                    # make sure string value is written as string
-                    if fields.get(field) == 10:
-                        query_syntax = f"{field} IN (\'{unique_values[0]}\')"
-
-                layer.setSubsetString(query_syntax)
-
-                if show_selected:
-                    feature_count = layer.featureCount()
-                    feature_plural_text = "feature" if feature_count == 1 else "features"
-                    value_plural_text = "value" if len(unique_values) == 1 else "values"
-                    iface.messageBar().pushMessage(f"{len(unique_values)} unique {value_plural_text} and {feature_count} {feature_plural_text} filtered", level=Qgis.Info)
-                else:
-                    iface.messageBar().pushMessage(f"{len(unique_values)} feature(s) filtered", level=Qgis.Info)
-            else:
-                iface.messageBar().pushMessage(f"{field} field does not exists", level=Qgis.Warning)
-        else:
+        if not len(selection):
             iface.messageBar().pushMessage("Nothing is selected!", level=Qgis.Warning)
+            return
+
+        fields = {f.name(): f.type() for f in layer.fields()}
+        if field not in fields:
+            iface.messageBar().pushMessage(f"{field} field does not exists", level=Qgis.Warning)
+            return
+
+        unique_values = list(set(feature[field] for feature in selection))
+
+        if len(unique_values) > 1:
+            query_syntax = f"{field} IN {tuple(unique_values)}"
+        else:
+            query_syntax = f"{field} IN ({unique_values[0]})"
+            # make sure string value is written as string
+            if fields.get(field) == 10:
+                query_syntax = f"{field} IN (\'{unique_values[0]}\')"
+
+        layer.setSubsetString(query_syntax)
+
+        if show_selected:
+            feature_count = layer.featureCount()
+            feature_plural_text = "feature" if feature_count == 1 else "features"
+            value_plural_text = "value" if len(unique_values) == 1 else "values"
+            iface.messageBar().pushMessage(f"{len(unique_values)} unique {value_plural_text} and {feature_count} {feature_plural_text} filtered", level=Qgis.Info)
+        else:
+            iface.messageBar().pushMessage(f"{len(unique_values)} feature(s) filtered", level=Qgis.Info)
 
     def filterSelected(self, layer:None):
         self._applySelectionFilter(show_selected=True)

--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -130,6 +130,16 @@ class SelectionFilter:
             pass
 
       
+    def _format_query(self, field, field_type, values, operator):
+        if len(values) > 1:
+            return f"{field} {operator} {tuple(values)}"
+        if field_type == 10:
+            return f"{field} {operator} ('{values[0]}')"
+        return f"{field} {operator} ({values[0]})"
+
+    def _build_query(self, field, field_type, unique_values):
+        return self._format_query(field, field_type, unique_values, "IN")
+
     def _applySelectionFilter(self, show_selected):
         layer = self.iface.activeLayer()
         field = layer.customProperty("unique_field", "")
@@ -137,14 +147,15 @@ class SelectionFilter:
             self.showSetUniqueFieldPopup(layer)
             field = layer.customProperty("unique_field", "")
 
+        original_count = layer.selectedFeatureCount()
+        if not original_count:
+            iface.messageBar().pushMessage("Nothing is selected!", level=Qgis.Warning)
+            return
+
         if not show_selected:
             layer.invertSelection()
 
         selection = layer.selectedFeatures()
-
-        if not len(selection):
-            iface.messageBar().pushMessage("Nothing is selected!", level=Qgis.Warning)
-            return
 
         fields = {f.name(): f.type() for f in layer.fields()}
         if field not in fields:
@@ -152,15 +163,7 @@ class SelectionFilter:
             return
 
         unique_values = list(set(feature[field] for feature in selection))
-
-        if len(unique_values) > 1:
-            query_syntax = f"{field} IN {tuple(unique_values)}"
-        else:
-            query_syntax = f"{field} IN ({unique_values[0]})"
-            # make sure string value is written as string
-            if fields.get(field) == 10:
-                query_syntax = f"{field} IN (\'{unique_values[0]}\')"
-
+        query_syntax = self._build_query(field, fields[field], unique_values)
         layer.setSubsetString(query_syntax)
 
         if show_selected:
@@ -169,7 +172,7 @@ class SelectionFilter:
             value_plural_text = "value" if len(unique_values) == 1 else "values"
             iface.messageBar().pushMessage(f"{len(unique_values)} unique {value_plural_text} and {feature_count} {feature_plural_text} filtered", level=Qgis.Info)
         else:
-            iface.messageBar().pushMessage(f"{len(unique_values)} feature(s) filtered", level=Qgis.Info)
+            iface.messageBar().pushMessage(f"{original_count} feature(s) hidden", level=Qgis.Info)
 
     def filterSelected(self, layer:None):
         self._applySelectionFilter(show_selected=True)

--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -142,32 +142,34 @@ class SelectionFilter:
             return f"{field} {operator} ('{values[0]}')"
         return f"{field} {operator} ({values[0]})"
 
+    def _shorter_query(self, field, field_type, in_values, not_in_values):
+        """Return IN (in_values) or NOT IN (not_in_values), whichever list is shorter."""
+        if not_in_values and len(not_in_values) < len(in_values):
+            return self._format_query(field, field_type, not_in_values, "NOT IN")
+        return self._format_query(field, field_type, in_values, "IN")
+
     def _build_query(self, layer, field, field_type, show_selected):
         selected_unique = list(set(f[field] for f in layer.selectedFeatures()))
-        not_selected_count = layer.featureCount() - len(selected_unique)
         prior_subset = layer.subsetString()
 
+        layer.invertSelection()
+        inverted_unique = list(set(f[field] for f in layer.selectedFeatures()))
+        layer.invertSelection()  # restore original selection
+
         if show_selected:
-            # IN (selected) is always correct.
-            # NOT IN (inverted) is shorter when inverted side is smaller, safe only with no prior subset.
-            if not prior_subset and not_selected_count < len(selected_unique):
-                layer.invertSelection()
-                inverted_unique = list(set(f[field] for f in layer.selectedFeatures()))
-                layer.invertSelection()  # restore original selection
-                return self._format_query(field, field_type, inverted_unique, "NOT IN")
+            # IN (selected) always replaces the prior filter cleanly — no AND needed.
+            # NOT IN (inverted) is only safe when there is no prior subset, because
+            # NOT IN on the full layer could expose features outside the prior view.
+            if not prior_subset:
+                return self._shorter_query(field, field_type, selected_unique, inverted_unique)
             return self._format_query(field, field_type, selected_unique, "IN")
         else:
-            # NOT IN (selected) composed with the prior subset is always correct and
-            # shorter when the selected side is smaller than the inverted side.
-            if len(selected_unique) <= not_selected_count:
-                not_in_query = self._format_query(field, field_type, selected_unique, "NOT IN")
-                if prior_subset:
-                    return f"{prior_subset}\nAND {not_in_query}"
-                return not_in_query
-            # Inverted side is shorter: use IN (inverted within current subset).
-            layer.invertSelection()
-            inverted_unique = list(set(f[field] for f in layer.selectedFeatures()))
-            return self._format_query(field, field_type, inverted_unique, "IN")
+            # For hide, NOT IN (selected) is short but must be scoped.
+            # Compose with prior_subset via AND when NOT IN is chosen.
+            query = self._shorter_query(field, field_type, inverted_unique, selected_unique)
+            if "NOT IN" in query and prior_subset:
+                return f"({prior_subset}) AND {query}"
+            return query
 
     def _applySelectionFilter(self, show_selected):
         layer = self.iface.activeLayer()

--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -130,57 +130,23 @@ class SelectionFilter:
             pass
 
       
-    def filterSelected(self, layer:None):
-
-        layer = self.iface.activeLayer() 
-        field = layer.customProperty("unique_field", "") #stored unique field for this layer        
-        if not field:
-            self.showSetUniqueFieldPopup(layer)
-            field = layer.customProperty("unique_field", "")
-            
-        selection = layer.selectedFeatures()
-        
-        if len(selection):
-            fields = {f.name():f.type() for f in layer.fields()}
-            if field in fields:
-                values = [feature[field] for feature in selection ]
-                unique_values = list(set(values))
-
-                if len(unique_values) > 1:
-                    query_syntax = f"{field} IN {tuple(unique_values)}"
-                else:
-                    query_syntax = f"{field} IN ({unique_values[0]})"
-                    # make sure string value is written as string
-                    if fields.get(field) == 10:
-                        query_syntax = f"{field} IN (\'{unique_values[0]}\')"
-                    
-                    
-                layer.setSubsetString(query_syntax)
-                
-                feature_count = layer.featureCount()
-                feature_plural_text = "feature" if feature_count == 1 else "features"
-                value_plural_text = "value" if len(unique_values) == 1 else "values"
-                iface.messageBar().pushMessage(f"{len(unique_values)} unique {value_plural_text} and {feature_count} {feature_plural_text} filtered", level=Qgis.Info)
-            else:               
-                iface.messageBar().pushMessage(f"{field} field does not exists",level=Qgis.Warning)
-
-        else:
-            iface.messageBar().pushMessage("Nothing is selected!",level=Qgis.Warning)
-
-    def hideSelected(self, layer:None):
-        layer = self.iface.activeLayer() 
+    def _applySelectionFilter(self, show_selected):
+        layer = self.iface.activeLayer()
         field = layer.customProperty("unique_field", "")
         if not field:
             self.showSetUniqueFieldPopup(layer)
             field = layer.customProperty("unique_field", "")
-        layer.invertSelection()    
+
+        if not show_selected:
+            layer.invertSelection()
+
         selection = layer.selectedFeatures()
-        
+
         if len(selection):
-            fields = {f.name():f.type() for f in layer.fields()}            
+            fields = {f.name(): f.type() for f in layer.fields()}
             if field in fields:
-                unique_values = [feature[field] for feature in selection ]
-                unique_values = list(set(unique_values))
+                unique_values = list(set(feature[field] for feature in selection))
+
                 if len(unique_values) > 1:
                     query_syntax = f"{field} IN {tuple(unique_values)}"
                 else:
@@ -188,15 +154,26 @@ class SelectionFilter:
                     # make sure string value is written as string
                     if fields.get(field) == 10:
                         query_syntax = f"{field} IN (\'{unique_values[0]}\')"
-                                    
-                layer.setSubsetString(query_syntax)
-                
-                iface.messageBar().pushMessage(f"{len(unique_values)} feature(s) filtered", level=Qgis.Info)
-            else:               
-                iface.messageBar().pushMessage(f"{field} field does not exists",level=Qgis.Warning)
 
+                layer.setSubsetString(query_syntax)
+
+                if show_selected:
+                    feature_count = layer.featureCount()
+                    feature_plural_text = "feature" if feature_count == 1 else "features"
+                    value_plural_text = "value" if len(unique_values) == 1 else "values"
+                    iface.messageBar().pushMessage(f"{len(unique_values)} unique {value_plural_text} and {feature_count} {feature_plural_text} filtered", level=Qgis.Info)
+                else:
+                    iface.messageBar().pushMessage(f"{len(unique_values)} feature(s) filtered", level=Qgis.Info)
+            else:
+                iface.messageBar().pushMessage(f"{field} field does not exists", level=Qgis.Warning)
         else:
-            iface.messageBar().pushMessage("Nothing is selected!",level=Qgis.Warning)
+            iface.messageBar().pushMessage("Nothing is selected!", level=Qgis.Warning)
+
+    def filterSelected(self, layer:None):
+        self._applySelectionFilter(show_selected=True)
+
+    def hideSelected(self, layer:None):
+        self._applySelectionFilter(show_selected=False)
             
     def clearFilterSelected(self, layer:None):
         layer = self.iface.activeLayer()
@@ -234,7 +211,7 @@ class SelectionFilter:
             self.popup.comboBoxFields.setCurrentText(field) 
         try:
             self.popup.show()
-        except:
+        except Exception:
             pass
         
         ok = self.popup.exec()

--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -21,13 +21,18 @@
  ***************************************************************************/
  """
 
-from qgis.core import (QgsApplication, QgsMapLayerType, QgsProject, QgsMessageLog, Qgis)
-#from qgis.PyQt.QtWidgets import QAction
-from qgis.PyQt.QtGui import QIcon, QAction
-from qgis.PyQt.QtCore import QCoreApplication
-from qgis.utils import iface
 import os
+
+from qgis.core import Qgis, QgsMapLayerType, QgsProject
+from qgis.PyQt.QtCore import QCoreApplication
+
+#from qgis.PyQt.QtWidgets import QAction
+from qgis.PyQt.QtGui import QAction, QIcon
+from qgis.utils import iface
+
 from .setUniqueField import setUniqueFieldPopup
+
+
 class SelectionFilter:
     def __init__(self, iface):
         super().__init__()

--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -137,8 +137,32 @@ class SelectionFilter:
             return f"{field} {operator} ('{values[0]}')"
         return f"{field} {operator} ({values[0]})"
 
-    def _build_query(self, field, field_type, unique_values):
-        return self._format_query(field, field_type, unique_values, "IN")
+    def _build_query(self, layer, field, field_type, show_selected):
+        selected_unique = list(set(f[field] for f in layer.selectedFeatures()))
+        not_selected_count = layer.featureCount() - len(selected_unique)
+        prior_subset = layer.subsetString()
+
+        if show_selected:
+            # IN (selected) is always correct.
+            # NOT IN (inverted) is shorter when inverted side is smaller, safe only with no prior subset.
+            if not prior_subset and not_selected_count < len(selected_unique):
+                layer.invertSelection()
+                inverted_unique = list(set(f[field] for f in layer.selectedFeatures()))
+                layer.invertSelection()  # restore original selection
+                return self._format_query(field, field_type, inverted_unique, "NOT IN")
+            return self._format_query(field, field_type, selected_unique, "IN")
+        else:
+            # NOT IN (selected) composed with the prior subset is always correct and
+            # shorter when the selected side is smaller than the inverted side.
+            if len(selected_unique) <= not_selected_count:
+                not_in_query = self._format_query(field, field_type, selected_unique, "NOT IN")
+                if prior_subset:
+                    return f"{prior_subset}\nAND {not_in_query}"
+                return not_in_query
+            # Inverted side is shorter: use IN (inverted within current subset).
+            layer.invertSelection()
+            inverted_unique = list(set(f[field] for f in layer.selectedFeatures()))
+            return self._format_query(field, field_type, inverted_unique, "IN")
 
     def _applySelectionFilter(self, show_selected):
         layer = self.iface.activeLayer()
@@ -152,25 +176,19 @@ class SelectionFilter:
             iface.messageBar().pushMessage("Nothing is selected!", level=Qgis.Warning)
             return
 
-        if not show_selected:
-            layer.invertSelection()
-
-        selection = layer.selectedFeatures()
-
         fields = {f.name(): f.type() for f in layer.fields()}
         if field not in fields:
             iface.messageBar().pushMessage(f"{field} field does not exists", level=Qgis.Warning)
             return
 
-        unique_values = list(set(feature[field] for feature in selection))
-        query_syntax = self._build_query(field, fields[field], unique_values)
+        field_type = fields[field]
+        query_syntax = self._build_query(layer, field, field_type, show_selected)
         layer.setSubsetString(query_syntax)
 
         if show_selected:
             feature_count = layer.featureCount()
             feature_plural_text = "feature" if feature_count == 1 else "features"
-            value_plural_text = "value" if len(unique_values) == 1 else "values"
-            iface.messageBar().pushMessage(f"{len(unique_values)} unique {value_plural_text} and {feature_count} {feature_plural_text} filtered", level=Qgis.Info)
+            iface.messageBar().pushMessage(f"{feature_count} {feature_plural_text} filtered", level=Qgis.Info)
         else:
             iface.messageBar().pushMessage(f"{original_count} feature(s) hidden", level=Qgis.Info)
 

--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -136,6 +136,8 @@ class SelectionFilter:
 
       
     def _format_query(self, field, field_type, values, operator):
+        if not values:
+            return "1 = 1" if operator == "NOT IN" else "1 = 0"
         if len(values) > 1:
             return f"{field} {operator} {tuple(values)}"
         if field_type == 10:

--- a/SelectionFilter.py
+++ b/SelectionFilter.py
@@ -168,7 +168,7 @@ class SelectionFilter:
             # Compose with prior_subset via AND when NOT IN is chosen.
             query = self._shorter_query(field, field_type, inverted_unique, selected_unique)
             if "NOT IN" in query and prior_subset:
-                return f"({prior_subset}) AND {query}"
+                return f"{prior_subset}\nAND {query}"
             return query
 
     def _applySelectionFilter(self, show_selected):


### PR DESCRIPTION
use `NOT IN` filter depending on the number of features to show/hide for better performance.
remove duplicate code in `filterSelected` and `hideSelected` by using `_applySelectionFilter` method and other helper methods.